### PR TITLE
Add weights to nodes to influence search paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Basic Usage
 To build a grid-map of width 5 and height 3:
 
 ```javascript
-var grid = new PF.Grid(5, 3); 
+var grid = new PF.Grid(5, 3);
 ```
 
 By default, all the nodes in the grid will be able to be walked through.
 To set whether a node at a given coordinate is walkable or not, use the `setWalkableAt` method.
 
-For example, to set the node at (0, 1) to be un-walkable, where 0 is the x coordinate (from left to right), and 
+For example, to set the node at (0, 1) to be un-walkable, where 0 is the x coordinate (from left to right), and
 1 is the y coordinate (from up to down):
 
 ```javascript
@@ -205,6 +205,19 @@ you may use `PF.Util.expandPath`.
 var newPath = PF.Util.expandPath(path);
 ```
 
+There is an optional weight that can be assigned to each node in the grid. This
+functions as a multiplier to the next g value calculated for each neighbor.  By
+setting the weight for a given node higher than 1 you make it less likely that
+the finder will examine that node.  By setting the weight lower than 1 you make
+it more likely the finder will examine that node.  The default value is 1 which will not impact the next g calculation at all.
+
+There are two calls, a getter and a setter to examine or set the weight for a given node.
+These are accessed via the grid object.
+
+```javascript
+var w = grid.getWeightAt(x,y); // returns the current weight value for the node at x,y
+grid.setWeightAt(x,y, weight); // sets the weight for the node at x,y
+```
 
 Development
 ------------
@@ -219,9 +232,9 @@ Layout:
 	|-- benchmark    # benchmarks
     `-- visual       # visualization
 
-Make sure you have `node.js` installed, then use `npm` to install the dependencies: 
+Make sure you have `node.js` installed, then use `npm` to install the dependencies:
 
-    npm install -d 
+    npm install -d
 
 The build system uses gulp, so make sure you have it installed:
 

--- a/docs/contributor-guide/authors.md
+++ b/docs/contributor-guide/authors.md
@@ -5,6 +5,7 @@ This is the alphabetically sorted list of contributors to PathFinding.js:
 Anders Riutta <https://github.com/ariutta><br>
 Chris Khoo <https://github.com/chriskck><br>
 Gerjo <https://github.com/Gerjo><br>
+James Brown <https://github.com/jbrown123><br>
 Juan Pablo Canepa <https://github.com/jpcanepa><br>
 Mat Gadd <https://github.com/Drarok><br>
 Murilo Pereira <https://github.com/mpereira><br>

--- a/docs/user-guide/diagonal-movement.md
+++ b/docs/user-guide/diagonal-movement.md
@@ -12,7 +12,7 @@ var finder = new PF.AStarFinder({
 
 See that the path is straight now:
 
-![Screenshot](user-guide/images/DiagonalMovementDisabled.png)
+![Screenshot](images/DiagonalMovementDisabled.png)
 
 The `diagonalMovement` option can take any of the following values:
 
@@ -25,28 +25,28 @@ To understand them consider the following four simple maps labelled A, B, C and
 D. A has no obstacles for diagonal movement from green to orange cell, B and C
 have one obstacle and D has two obstacles.
 
-![Screenshot](user-guide/images/DiagonalMaps.png)
+![Screenshot](images/DiagonalMaps.png)
 
 ## Always
 With this option PathFinding.js will always find a diagonal path, irrespective
 of the obstacles when moving diagonally.
 
-![Screenshot](user-guide/images/AllMapsWithAPath.png)
+![Screenshot](images/AllMapsWithAPath.png)
 
 ## Never
 With this option PathFinding.js will only find straight paths and will never
 find any diagonal paths.
 
-![Screenshot](user-guide/images/AllMapsWithStraightPaths.png)
+![Screenshot](images/AllMapsWithStraightPaths.png)
 
 ## IfAtMostOneObstacle
 With this option PathFinding.js will find diagonal paths only if there is at
 most one obstacle for the diagonal path.
 
-![Screenshot](user-guide/images/DiagonalPathsForAtMostOneObstacle.png)
+![Screenshot](images/DiagonalPathsForAtMostOneObstacle.png)
 
 ## OnlyWhenNoObstacles
 With this option PathFinding.js will find diagonal paths only if there are no
 obstacles for the diagonal path.
 
-![Screenshot](user-guide/images/DiagonalPathsForOnlyWhenNoObstacles.png)
+![Screenshot](images/DiagonalPathsForOnlyWhenNoObstacles.png)

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -23,7 +23,7 @@ var grid = new PF.Grid(5, 7);
 ```
 This will create a grid which is walkable all over.
 
-![Screenshot](user-guide/images/5x7EmptyGrid.png)
+![Screenshot](images/5x7EmptyGrid.png)
 
 In this grid, the green cell at the top left is [0, 0] and the orange cell at
 the bottom right is [4, 6].
@@ -49,4 +49,4 @@ This will return the following path:
 
 Which when plotted on the grid looks like:
 
-![Screenshot](user-guide/images/5x7GridWithPath.png)
+![Screenshot](images/5x7GridWithPath.png)

--- a/docs/user-guide/obstacles.md
+++ b/docs/user-guide/obstacles.md
@@ -26,7 +26,7 @@ grid.setWalkableAt(2, 1, false);
 
 After setting the obstacles the grid should look like this.
 
-![Screenshot](user-guide/images/5x7GridWithObstacles.png)
+![Screenshot](images/5x7GridWithObstacles.png)
 
 Let us find a path now.
 
@@ -37,7 +37,7 @@ var path = finder.findPath(0, 0, 4, 6, grid);
 
 PathFinding.js will find the following path:
 
-![Screenshot](user-guide/images/5x7GridWithObstaclesAndPath.png)
+![Screenshot](images/5x7GridWithObstaclesAndPath.png)
 
 Notice how the path moves diagonally where it can, thus making it shorter. This
 may not be always desirable and you may want to create a path without any

--- a/src/core/Grid.js
+++ b/src/core/Grid.js
@@ -124,6 +124,30 @@ Grid.prototype.setWalkableAt = function(x, y, walkable) {
 
 
 /**
+ * Set the weight multiplier of a given node
+ * NOTE: if it is unset, we will return 1 since this will do nothing
+ * @param {number} x - The x coordinate of the node.
+ * @param {number} y - The y coordinate of the node.
+ * @param {number} weight - Weight multiplier of the node
+ */
+Grid.prototype.setWeightAt = function(x, y, weight) {
+    if (this.isInside(x, y))
+        this.nodes[y][x].weight = weight;
+};
+
+/**
+ * Determine the weight mulitpler of a given node.
+ * (Also returns 1 if the position is outside the grid.)
+ * @param {number} x - The x coordinate of the node.
+ * @param {number} y - The y coordinate of the node.
+ * @return {number} - The weight multiplier of the node.
+ */
+Grid.prototype.getWeightAt = function(x, y) {
+    return this.isInside(x, y) ? this.nodes[y][x].weight : 1;
+};
+
+
+/**
  * Get the neighbors of the given node.
  *
  *     offsets      diagonalOffsets:
@@ -233,7 +257,7 @@ Grid.prototype.clone = function() {
     for (i = 0; i < height; ++i) {
         newNodes[i] = new Array(width);
         for (j = 0; j < width; ++j) {
-            newNodes[i][j] = new Node(j, i, thisNodes[i][j].walkable);
+            newNodes[i][j] = new Node(j, i, thisNodes[i][j].walkable, thisNodes[i][j].weight);
         }
     }
 

--- a/src/core/Node.js
+++ b/src/core/Node.js
@@ -7,7 +7,7 @@
  * @param {number} y - The y coordinate of the node on the grid.
  * @param {boolean} [walkable] - Whether this node is walkable.
  */
-function Node(x, y, walkable) {
+function Node(x, y, walkable, weight) {
     /**
      * The x coordinate of the node on the grid.
      * @type number
@@ -23,6 +23,11 @@ function Node(x, y, walkable) {
      * @type boolean
      */
     this.walkable = (walkable === undefined ? true : walkable);
+    /**
+     * weight multiplier of this node.
+     * @type number (defaults to 1)
+     */
+    this.weight = (weight === undefined ? 1 : weight);
 }
 
 module.exports = Node;

--- a/src/finders/AStarFinder.js
+++ b/src/finders/AStarFinder.js
@@ -97,7 +97,9 @@ AStarFinder.prototype.findPath = function(startX, startY, endX, endY, grid) {
             // get the distance between current node and the neighbor
             // and calculate the next g score
             ng = node.g + ((x - node.x === 0 || y - node.y === 0) ? 1 : SQRT2);
-
+            
+            ng *= neighbor.weight;
+            
             // check if the neighbor has not been inspected yet, or
             // can be reached with smaller cost from the current node
             if (!neighbor.opened || ng < neighbor.g) {

--- a/src/finders/BiAStarFinder.js
+++ b/src/finders/BiAStarFinder.js
@@ -107,6 +107,8 @@ BiAStarFinder.prototype.findPath = function(startX, startY, endX, endY, grid) {
             // and calculate the next g score
             ng = node.g + ((x - node.x === 0 || y - node.y === 0) ? 1 : SQRT2);
 
+            ng *= neighbor.weight;
+
             // check if the neighbor has not been inspected yet, or
             // can be reached with smaller cost from the current node
             if (!neighbor.opened || ng < neighbor.g) {

--- a/src/finders/JumpPointFinderBase.js
+++ b/src/finders/JumpPointFinderBase.js
@@ -94,6 +94,8 @@ JumpPointFinderBase.prototype._identifySuccessors = function(node) {
             d = Heuristic.octile(abs(jx - x), abs(jy - y));
             ng = node.g + d; // next `g` value
 
+            ng *= neighbor.weight;
+
             if (!jumpNode.opened || ng < jumpNode.g) {
                 jumpNode.g = ng;
                 jumpNode.h = jumpNode.h || heuristic(abs(jx - endX), abs(jy - endY));


### PR DESCRIPTION
"I added a weight value to each node. These weights are used in A* based finders and the Jump point base finder when calculating the next g value for a given node.

I did this because the finders tend to hug the walls of obstacles in the grid. This may not be the most desirable behavior so by using individual weights you can influence the paths the finders evaluate. This can encourage, but not require, the finder to stay a bit away from the walls when searching for a path.

For some reason my editor seems to have changed white space in some of the files which causes diff to think they are all different. Honestly this is only a few lines of changed code."